### PR TITLE
Change runltp-ng LTP install folder name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,14 +7,14 @@ top_srcdir		?= ../..
 
 include $(top_srcdir)/include/mk/env_pre.mk
 
-INSTALL_DIR		:= $(DESTDIR)/$(bindir)
+INSTALL_DIR		:= $(prefix)/runltp-ng.d
 
 install:
-	mkdir -p $(INSTALL_DIR)/runltp-ng/ltp
+	mkdir -p $(INSTALL_DIR)/ltp
 
-	install -m 00644 $(top_srcdir)/tools/runltp-ng/ltp/*.py $(INSTALL_DIR)/runltp-ng/ltp
-	install -m 00775 $(top_srcdir)/tools/runltp-ng/runltp-ng $(INSTALL_DIR)/runltp-ng/runltp-ng
+	install -m 00644 $(top_srcdir)/tools/runltp-ng/ltp/*.py $(INSTALL_DIR)/ltp
+	install -m 00775 $(top_srcdir)/tools/runltp-ng/runltp-ng $(INSTALL_DIR)/runltp-ng
 
-	ln -sf $(INSTALL_DIR)/runltp-ng/runltp-ng $(DESTDIR)/$(prefix)/runltp-ng
+	ln -sf $(INSTALL_DIR)/runltp-ng $(prefix)/runltp-ng
 
 include $(top_srcdir)/include/mk/generic_leaf_target.mk


### PR DESCRIPTION
runltp-ng install folder has been moved inside the default LTP install folder under runltp-ng.d. In this way we move it out of the binary folder and keep it visible inside the LTP installation.

Signed-off-by: Andrea Cervesato <andrea.cervesato@suse.com>
Reviewed-by: Petr Vorel <pvorel@suse.cz>
Tested-by: Petr Vorel <pvorel@suse.cz>