### PR TITLE
Add metadata support

### DIFF
--- a/ltp/dispatcher.py
+++ b/ltp/dispatcher.py
@@ -9,6 +9,7 @@ import os
 import re
 import sys
 import time
+import json
 import logging
 import threading
 import ltp
@@ -282,6 +283,12 @@ class SerialDispatcher(Dispatcher):
         """
         suites_obj = []
 
+        metadata_path = os.path.join(self._ltpdir, "metadata", "ltp.json")
+        metadata_json = None
+        if os.path.isfile(metadata_path):
+            with open(metadata_path, 'r', encoding='utf-8') as metadata:
+                metadata_json = json.loads(metadata.read())
+
         for suite_name in suites:
             target = os.path.join(self._ltpdir, "runtest", suite_name)
 
@@ -300,7 +307,10 @@ class SerialDispatcher(Dispatcher):
                 suite_name,
                 target)
 
-            suite = ltp.data.read_runtest(suite_name, data_str)
+            suite = ltp.data.read_runtest(
+                suite_name,
+                data_str,
+                metadata=metadata_json)
             suites_obj.append(suite)
 
         return suites_obj

--- a/ltp/tests/test_data.py
+++ b/ltp/tests/test_data.py
@@ -27,7 +27,37 @@ def test_read_runtest():
     assert suite.tests[0].name == "test01"
     assert suite.tests[0].command == "test"
     assert suite.tests[0].arguments == ['-f', '.']
+    assert not suite.tests[0].parallelizable
 
     assert suite.tests[1].name == "test02"
     assert suite.tests[1].command == "test"
     assert suite.tests[1].arguments == ['-d', '.']
+    assert not suite.tests[1].parallelizable
+
+
+def test_read_runtest_metadata_blacklist():
+    """
+    Test read_runtest method using metadata to blacklist some tests.
+    """
+    for param in ltp.data.PARALLEL_BLACKLIST:
+        content = "# this is a test file\ntest01 test -f .\ntest02 test -d .\n"
+        metadata = {
+            "tests": {
+                "test01": {
+                    param: "myvalue"
+                },
+                "test02": {}
+            }
+        }
+        suite = ltp.data.read_runtest("suite", content, metadata=metadata)
+
+        assert suite.name == "suite"
+        assert suite.tests[0].name == "test01"
+        assert suite.tests[0].command == "test"
+        assert suite.tests[0].arguments == ['-f', '.']
+        assert not suite.tests[0].parallelizable
+
+        assert suite.tests[1].name == "test02"
+        assert suite.tests[1].command == "test"
+        assert suite.tests[1].arguments == ['-d', '.']
+        assert suite.tests[1].parallelizable


### PR DESCRIPTION
This is a first step toward parallel execution. We read metadata provided by the new LTP API and check if test can run in parallel or not. The choice is based on flags we are reading from metadata which are defined inside the ltp.data.PARALLEL_BLACKLIST list.