### PR TITLE
Fix runltp-ng installation inside LTP buildsystem

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,12 +7,13 @@ top_srcdir		?= ../..
 
 include $(top_srcdir)/include/mk/env_pre.mk
 
-INSTALL_DIR		:= $(prefix)/runltp-ng.d
+BASE_DIR		:= $(abspath $(DESTDIR)/$(prefix))
+INSTALL_DIR		:= $(BASE_DIR)/runltp-ng.d
 
 install:
 	mkdir -p $(INSTALL_DIR)/ltp
 
 	install -m 00644 $(top_srcdir)/tools/runltp-ng/ltp/*.py $(INSTALL_DIR)/ltp
-	install -m 00775 $(top_srcdir)/tools/runltp-ng/runltp-ng $(INSTALL_DIR)/runltp-ng
+	install -m 00775 $(top_srcdir)/tools/runltp-ng/runltp-ng $(BASE_DIR)/runltp-ng
 
 include $(top_srcdir)/include/mk/generic_leaf_target.mk

--- a/runltp-ng
+++ b/runltp-ng
@@ -13,6 +13,10 @@ import sys
 
 # include ltp library
 sys.path.insert(0, os.path.abspath(os.path.dirname(__file__)))
+sys.path.insert(0, os.path.abspath(os.path.join(
+    os.path.dirname(__file__),
+    "runltp-ng.d")
+))
 
 if __name__ == "__main__":
     import ltp.main


### PR DESCRIPTION
Added runltp-ng.d folder to the PYTHONPATH inside runltp-ng script. Also introduced BASE_DIR inside Makefile because ${prefix} is breaking installation on build systems.

Signed-off-by: Andrea Cervesato <andrea.cervesato@suse.com>