### PR TITLE
Stabilize SUT reboot during tests execution

### DIFF
--- a/ltp/dispatcher.py
+++ b/ltp/dispatcher.py
@@ -317,9 +317,10 @@ class SerialDispatcher(Dispatcher):
         else:
             self._sut.stop(timeout=360)
 
-        self._sut.communicate(
+        self._sut.ensure_communicate(
             timeout=3600,
-            iobuffer=RedirectStdout(self._sut))
+            iobuffer=RedirectStdout(self._sut),
+            force=force)
 
         self._logger.info("SUT rebooted")
 

--- a/ltp/qemu.py
+++ b/ltp/qemu.py
@@ -495,7 +495,10 @@ class QemuSUT(SUT):
                     self._wait_for("Password:", 5, iobuffer)
                     self._write_stdin(f"{self._password}\n")
 
+                time.sleep(0.2)
+
                 self._wait_for("#", 5, iobuffer)
+                time.sleep(0.2)
 
                 self._write_stdin("stty -echo; stty cols 1024\n")
                 self._wait_for("#", 5, None)

--- a/ltp/session.py
+++ b/ltp/session.py
@@ -185,7 +185,7 @@ class Session:
 
         ltp.events.fire("sut_start", sut.name)
 
-        sut.communicate(
+        sut.ensure_communicate(
             timeout=3600,
             iobuffer=Printer(sut, False))
 

--- a/ltp/tests/sut.py
+++ b/ltp/tests/sut.py
@@ -90,6 +90,17 @@ class _TestSUT:
             sut.communicate(iobuffer=Printer())
         sut.stop()
 
+    def test_ensure_communicate(self, sut):
+        """
+        Test ensure_communicate method.
+        """
+        sut.ensure_communicate(iobuffer=Printer())
+        with pytest.raises(SUTError):
+            sut.ensure_communicate(iobuffer=Printer(), retries=1)
+
+        sut.ensure_communicate(iobuffer=Printer(), retries=10)
+        sut.stop()
+
     @pytest.fixture
     def sut_stop_sleep(self, request):
         """


### PR DESCRIPTION
Sometimes SUT object might have communication problems after restarting it. With this patch we retry 10 times before considering SUT communication broken.

Signed-off-by: Andrea Cervesato <andrea.cervesato@suse.com>