### PR TITLE
Kill qemu properly if communication fails

### DIFF
--- a/ltp/sut.py
+++ b/ltp/sut.py
@@ -15,13 +15,13 @@ class SUTError(LTPException):
     """
 
 
-class SUTTimeoutError(LTPException):
+class SUTTimeoutError(SUTError):
     """
     Raised when timeout error occurs in SUT.
     """
 
 
-class KernelPanicError(LTPException):
+class KernelPanicError(SUTError):
     """
     Raised during kernel panic.
     """


### PR DESCRIPTION
During the first communication with qemu, we are currently catching the wrong exception in case of error, causing application to remain a zombie process. This patch will fix the problem.

Signed-off-by: Andrea Cervesato <andrea.cervesato@suse.com>